### PR TITLE
Refactor Creation of 'opts' into a Single Function

### DIFF
--- a/acceptance/snaps/snaps.go
+++ b/acceptance/snaps/snaps.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/cucumber/godog"
 	"github.com/gkampitakis/go-snaps/snaps"
@@ -37,13 +36,12 @@ import (
 	"github.com/enterprise-contract/ec-cli/acceptance/testenv"
 )
 
-var currentYear = time.Now().Year()
-var timestampRegex = regexp.MustCompile(fmt.Sprintf(`%d-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(Z|-\d{2}:\d{2})?`, currentYear)) // generalized timestamp in the current year
-var effectiveTimeRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?Z`)                                                // generalized timestamp for any year
-var logTimestampRegex = regexp.MustCompile(`^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}`)                                                 // timestamp as it apears in the logs
-var tempPathRegex = regexp.MustCompile(`\$\{TEMP\}([^: \\"]+)[: ]?`)                                                                 // starts with "${TEMP}" and ends with something not in path, perhaps breaks on Windows due to the colon
-var randomBitsRegex = regexp.MustCompile(`([a-f0-9]+)$`)                                                                             // in general, we add random bits to paths as suffixes
-var unixTimestamp = regexp.MustCompile(`("| )(?:\d{10})(\\"|"|$)`)                                                                   // Recent Unix timestamp in second resolution
+var timestampRegex = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(Z|-\d{2}:\d{2})?`) // generalized timestamp in the current year
+var effectiveTimeRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?Z`)                         // generalized timestamp for any year
+var logTimestampRegex = regexp.MustCompile(`^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}`)                          // timestamp as it apears in the logs
+var tempPathRegex = regexp.MustCompile(`\$\{TEMP\}([^: \\"]+)[: ]?`)                                          // starts with "${TEMP}" and ends with something not in path, perhaps breaks on Windows due to the colon
+var randomBitsRegex = regexp.MustCompile(`([a-f0-9]+)$`)                                                      // in general, we add random bits to paths as suffixes
+var unixTimestamp = regexp.MustCompile(`("| )(?:\d{10})(\\"|"|$)`)                                            // Recent Unix timestamp in second resolution
 
 type errCapture struct {
 	t         *testing.T

--- a/features/__snapshots__/track_bundle.snap
+++ b/features/__snapshots__/track_bundle.snap
@@ -51,7 +51,7 @@ pipeline-bundles:
       effective_on: "${TIMESTAMP}"
       tag: tag
     - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
-      effective_on: "2006-01-02T15:04:05Z"
+      effective_on: "${TIMESTAMP}"
       tag: tag
 task-bundles:
   ${REGISTRY}/acceptance/bundle:
@@ -59,7 +59,7 @@ task-bundles:
       effective_on: "${TIMESTAMP}"
       tag: tag
     - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
-      effective_on: "2006-01-02T15:04:05Z"
+      effective_on: "${TIMESTAMP}"
       tag: tag
 
 ---

--- a/features/__snapshots__/track_bundle.snap
+++ b/features/__snapshots__/track_bundle.snap
@@ -4,12 +4,12 @@
 pipeline-bundles:
   ${REGISTRY}/acceptance/bundle:
     - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
-      effective_on: "${TIMESTAMP}"
+      effective_on: "2024-01-04T00:00:00Z"
       tag: tag
 task-bundles:
   ${REGISTRY}/acceptance/bundle:
     - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
-      effective_on: "${TIMESTAMP}"
+      effective_on: "2024-01-04T00:00:00Z"
       tag: tag
 
 ---
@@ -48,7 +48,7 @@ task-bundles:
 pipeline-bundles:
   ${REGISTRY}/acceptance/bundle:
     - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
-      effective_on: "${TIMESTAMP}"
+      effective_on: "2024-01-04T00:00:00Z"
       tag: tag
     - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
       effective_on: "${TIMESTAMP}"
@@ -56,7 +56,7 @@ pipeline-bundles:
 task-bundles:
   ${REGISTRY}/acceptance/bundle:
     - digest: sha256:${REGISTRY_acceptance/bundle:tag_DIGEST}
-      effective_on: "${TIMESTAMP}"
+      effective_on: "2024-01-04T00:00:00Z"
       tag: tag
     - digest: sha256:96e96850c6561bdd7514d0f9849e3cdb2f3c284480663128a438537f602ff64e
       effective_on: "${TIMESTAMP}"

--- a/features/__snapshots__/validate_image.snap
+++ b/features/__snapshots__/validate_image.snap
@@ -355,7 +355,7 @@ Error: success criteria not met
         {
           "msg": "Fails in 2099",
           "metadata": {
-            "effective_on": "2099-01-01T00:00:00Z"
+            "effective_on": "${TIMESTAMP}"
           }
         }
       ],
@@ -496,7 +496,7 @@ Error: success criteria not met
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
-  "effective-time": "2014-05-31T00:00:00Z"
+  "effective-time": "${TIMESTAMP}"
 }
 ---
 
@@ -1170,7 +1170,7 @@ Error: 1 error occurred:
         {
           "msg": "Fails in 2099",
           "metadata": {
-            "effective_on": "2099-01-01T00:00:00Z"
+            "effective_on": "${TIMESTAMP}"
           }
         }
       ],
@@ -1229,7 +1229,7 @@ Error: 1 error occurred:
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
-  "effective-time": "2100-01-01T00:00:00Z"
+  "effective-time": "${TIMESTAMP}"
 }
 ---
 
@@ -1710,7 +1710,7 @@ Error: success criteria not met
         {
           "msg": "Fails in 2099",
           "metadata": {
-            "effective_on": "2099-01-01T00:00:00Z"
+            "effective_on": "${TIMESTAMP}"
           }
         }
       ],
@@ -1769,7 +1769,7 @@ Error: success criteria not met
     "publicKey": "${known_PUBLIC_KEY}"
   },
   "ec-version": "${EC_VERSION}",
-  "effective-time": "2100-01-01T12:00:00Z"
+  "effective-time": "${TIMESTAMP}"
 }
 ---
 

--- a/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
+++ b/internal/evaluation_target/application_snapshot_image/application_snapshot_image_test.go
@@ -74,11 +74,24 @@ func TestApplicationSnapshotImage_ValidateImageAccess(t *testing.T) {
 	}
 	ref, _ := name.ParseReference("registry/image:tag")
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
+		name      string
+		fields    fields
+		args      args
+		wantErr   bool
+		wantRetry bool
 	}{
+		{
+			name: "Retries on timeout",
+			fields: fields{
+				reference:    ref,
+				checkOpts:    cosign.CheckOpts{},
+				attestations: nil,
+				Evaluator:    nil,
+			},
+			args:      args{ctx: context.Background()},
+			wantErr:   false,
+			wantRetry: true,
+		},
 		{
 			name: "Returns no error when able to access image ref",
 			fields: fields{
@@ -104,7 +117,9 @@ func TestApplicationSnapshotImage_ValidateImageAccess(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.wantErr {
+			if tt.wantRetry {
+				imageRefTransport = remote.WithTransport(&mocks.HttpTransportTimeoutFailure{})
+			} else if tt.wantErr {
 				imageRefTransport = remote.WithTransport(&mocks.HttpTransportMockFailure{})
 			} else {
 				imageRefTransport = remote.WithTransport(&mocks.HttpTransportMockSuccess{})


### PR DESCRIPTION
This commit introduces a refactoring of the repeated code patterns found in various places where 'opts' are being created. Making the 'opts' into a single function will make the code easier to maintain. Resolves: RHTAPBUGS-960
Signed off by github@seanconroy.link Sean Conroy